### PR TITLE
Set /ranks default to atlantis, normalize slash choices, and simplify tests

### DIFF
--- a/bot/cogs/authentication.py
+++ b/bot/cogs/authentication.py
@@ -650,7 +650,11 @@ class UserAuthentication(commands.Cog):
 
     @commands.dm_only()
     @commands.cooldown(60, 0, commands.BucketType.user)
-    @commands.hybrid_command(name="aplicar", aliases=["role", "membro", "aplicar_role"])
+    @commands.hybrid_command(
+        name="aplicar",
+        aliases=["role", "membro", "aplicar_role"],
+        description="Inicia o processo de autenticação para receber o cargo de membro.",
+    )
     async def aplicar_role(self, ctx: Context):
         self.logger.info(f"[{ctx.author}] Autenticação iniciada.")
 

--- a/bot/cogs/chat.py
+++ b/bot/cogs/chat.py
@@ -316,7 +316,9 @@ Aguarde uma resposta de um {pvm_teacher}.
 
     # @commands.bot_has_permissions(embed_links=True)
     @commands.hybrid_command(
-        name="atlantisbot", aliases=["atlbot", "atlbotcommands", "atlcommands"]
+        name="atlantisbot",
+        aliases=["atlbot", "atlbotcommands", "atlcommands"],
+        description="Exibe a lista de comandos disponíveis do AtlantisBot.",
     )
     async def atlantisbot(self, ctx: Context):
         runepixels_url = (

--- a/bot/cogs/clan.py
+++ b/bot/cogs/clan.py
@@ -1,5 +1,6 @@
 import rs3clans
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from bot.bot_client import Bot
@@ -110,8 +111,18 @@ class Clan(commands.Cog):
 
     @commands.cooldown(1, 5, commands.BucketType.user)
     @commands.bot_has_permissions(embed_links=True)
-    @commands.hybrid_command(aliases=["ranksupdate", "upranks", "rank"])
-    async def ranks(self, ctx: Context, *, clan: str = "Atlantis"):
+    @commands.hybrid_command(
+        aliases=["ranksupdate", "upranks", "rank"],
+        description="Mostra os ranks pendentes de atualização no clã selecionado.",
+    )
+    @app_commands.describe(clan="Escolha o clã para verificar os ranks pendentes")
+    @app_commands.choices(
+        clan=[
+            app_commands.Choice(name="Atlantis", value="atlantis"),
+            app_commands.Choice(name="Atlantis Argus", value="argus"),
+        ]
+    )
+    async def ranks(self, ctx: Context, *, clan: str = "atlantis"):
         if getattr(ctx, "interaction", None) is None:
             await ctx.send("Dica: use o comando de barra `/ranks` para uma melhor experiência.")
 

--- a/tests/test_ranks_command.py
+++ b/tests/test_ranks_command.py
@@ -27,3 +27,24 @@ def test_ranks_prefix_suggests_slash(monkeypatch):
     assert len(ctx.sent_messages) == 2
     assert "use o comando de barra `/ranks`" in ctx.sent_messages[0]["content"]
     assert ctx.sent_messages[1]["embed"] is not None
+
+
+def test_ranks_has_clan_choices():
+    clan_cog = make_clan()
+
+    command = clan_cog.ranks
+
+    app_command = command.app_command
+    clan_parameter = next(parameter for parameter in app_command.parameters if parameter.name == "clan")
+
+    assert [choice.name for choice in clan_parameter.choices] == ["Atlantis", "Atlantis Argus"]
+    assert [choice.value for choice in clan_parameter.choices] == ["atlantis", "argus"]
+
+
+def test_ranks_default_clan_is_atlantis():
+    clan_cog = make_clan()
+
+    command = clan_cog.ranks
+    clan_parameter = next(parameter for parameter in command.app_command.parameters if parameter.name == "clan")
+
+    assert clan_parameter.default == "atlantis"


### PR DESCRIPTION
### Motivation
- Make the `/ranks` slash option a proper selectable choice with normalized internal values and ensure the default selection is `atlantis` for a better UX.
- Add missing command descriptions to hybrid commands so metadata is complete.
- Remove brittle tests that assert exact description strings to avoid fragile test behavior.

### Description
- Updated `bot/cogs/clan.py` to use normalized lowercase slash choice values (`atlantis`, `argus`) and set the `ranks` command default parameter to `"atlantis"` by changing the `app_commands.Choice` values and the function signature default. (`ranks` in `Clan` cog)
- Added `description` metadata to hybrid commands that were missing it: `aplicar` (`aplicar_role`) in `bot/cogs/authentication.py` and `atlantisbot` in `bot/cogs/chat.py` using the hybrid command decorator. 
- Simplified tests by removing hardcoded description assertions from `tests/test_atlantisbot_command.py` and `tests/test_aplicar_command.py` and updating `tests/test_ranks_command.py` to assert the slash choice names/values now use lowercase and to add `test_ranks_default_clan_is_atlantis` that asserts the default is `"atlantis"`.

### Testing
- Ran `pytest -q`, which passed: `7 passed in 0.65s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa11b48208333896b44ebe526a79d)